### PR TITLE
feat: add CLA (Contributor License Agreement)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,35 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_REPO_SECRET }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/ksj0109188/SwiftScissor/blob/main/CLA.md'
+          branch: 'main'
+
+          remote-organization-name: 'ksj0109188'
+          remote-repository-name: 'swiftscissor-clas'
+
+          # Exempt bots and repository owner from signing the CLA
+          allowlist: '*[bot],ksj0109188'
+
+          custom-notsigned-prcomment: 'Thank you for your contribution! Please sign the [CLA](https://github.com/ksj0109188/SwiftScissor/blob/main/CLA.md) before we can merge your pull request. You can sign the CLA by just posting a comment following the below format.'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,51 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to [SwiftScissor](https://github.com/ksj0109188/SwiftScissor) ("the Project"). This Contributor License Agreement ("CLA") ensures that your Contributions can be used in the Project while allowing you to retain ownership of your work.
+
+By signing this CLA, you accept and agree to the following terms for your present and future Contributions to the Project.
+
+## Definitions
+
+**"You"**: The individual or legal entity submitting Contributions to the Project.
+
+**"Contribution"**: Any original work of authorship, including source code, documentation, configuration files, or other materials, that you intentionally submit to the Project.
+
+**"Project"**: [SwiftScissor](https://github.com/ksj0109188/SwiftScissor).
+
+## 1. Grant of Rights
+
+**Copyright License**: You grant the Project maintainers and recipients a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, modify, publicly display, sublicense, and distribute your Contributions under the Apache License 2.0.
+
+**Patent License**: You grant a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license for any patent claims necessarily infringed by your Contributions. If you initiate patent litigation against the Project, your patent licenses terminate.
+
+## 2. Representations
+
+You represent that:
+
+a) You are legally entitled to grant the above licenses
+
+b) If employed, you have permission from your employer or your employer has waived rights to your Contributions
+
+c) Each Contribution is your original creation
+
+d) You will identify any third-party materials included in your Contributions
+
+## 3. Relicensing Rights
+
+You grant the Project maintainers the right to relicense your Contributions under any OSI-approved open-source license to ensure the Project can adapt its licensing while maintaining its open-source nature.
+
+## 4. Disclaimer
+
+You provide your Contributions "AS IS" without warranties of any kind. You are not required to provide support for your Contributions unless you choose to do so.
+
+## 5. How to Sign
+
+You may accept this CLA through the CLA assistant bot when submitting your first pull request.
+
+## 6. Acceptance
+
+By submitting a Contribution to the Project, you agree to be bound by the terms of this CLA. You may indicate your agreement on your PR.
+
+---
+
+*Questions? Contact the project maintainer.*


### PR DESCRIPTION
## Summary

Add Contributor License Agreement (CLA) requirement for all contributors to ensure legal clarity of contributed code.

## Changes

### Files Added
- **CLA.md**: Contributor License Agreement document
  - Based on industry-standard CLA format
  - Ensures contributors retain ownership while granting project usage rights
  - Compatible with Apache 2.0 license

- **.github/workflows/cla.yml**: GitHub Actions workflow
  - Automated CLA signature collection
  - Uses `contributor-assistant/github-action@v2.6.1`
  - Stores signatures in private repository: `swiftscissor-clas`

## How It Works

1. When a contributor opens their first PR, the CLA bot posts a comment
2. Contributor reads the CLA document
3. Contributor signs by commenting: `I have read the CLA Document and I hereby sign the CLA`
4. Bot verifies signature and updates PR status check
5. PR can be merged after CLA is signed

## Exemptions

- Repository owner (`ksj0109188`) is exempt
- Bots are exempt (`*[bot]`)

## Testing

This PR itself will test the CLA bot workflow (owner is exempt from signing).